### PR TITLE
ci(actionlint): split reporter by event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: reviewdog/action-actionlint@e58ee9d111489c31395fbe4857b0be6e7635dbda # v1.70.0
+      - name: Run actionlint (github-check)
+        uses: reviewdog/action-actionlint@e58ee9d111489c31395fbe4857b0be6e7635dbda # v1.70.0
+        if: github.event_name != 'pull_request'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-check
+          fail_level: error
+
+      - name: Run actionlint (github-pr-review)
+        uses: reviewdog/action-actionlint@e58ee9d111489c31395fbe4857b0be6e7635dbda # v1.70.0
+        if: github.event_name == 'pull_request'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
-          fail_level: error
 
       - name: List workflows for zizmor
         id: list-workflows


### PR DESCRIPTION
Summary:
- split actionlint into github-check and github-pr-review steps
- run github-check on non-pull_request events and keep pr review on pull_request
