### PR TITLE
fix: address SC2002 in markdownlint reviewdog step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,7 @@ jobs:
           markdownlint_rc=0
           npx --yes markdownlint-cli2 . > /tmp/markdownlint-report.txt 2>&1 || markdownlint_rc=$?
           reviewdog_rc=0
-          cat /tmp/markdownlint-report.txt |
-            reviewdog \
+          reviewdog < /tmp/markdownlint-report.txt \
               -efm="%f:%l:%c %m" \
               -efm="%f:%l %m" \
               -name=markdownlint \


### PR DESCRIPTION
- replace `cat ... | reviewdog` with stdin redirection\n- keep existing markdownlint/reviewdog failure handling