### PR TITLE
fix: resolve SC2002 in reviewdog pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,8 +276,7 @@ jobs:
               }
             }
           ' /tmp/clippy-report.json > /tmp/clippy-rdjsonl.txt || true
-          cat /tmp/clippy-rdjsonl.txt |
-            reviewdog \
+          reviewdog < /tmp/clippy-rdjsonl.txt \
               -f=rdjsonl \
               -name=clippy \
               -reporter=github-pr-review \


### PR DESCRIPTION
- replace `cat ... | reviewdog` with stdin redirection\n- keep current error-handling semantics