### PR TITLE
chore: pin CI tool versions and refine Renovate rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,6 +36,30 @@
     {
       fileMatch: ["^\\.github/workflows/ci\\.ya?ml$"],
       matchStrings: [
+        "go install github\\.com/rhysd/actionlint/cmd/actionlint@(?<currentValue>v\\S+)",
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "rhysd/actionlint",
+    },
+    {
+      fileMatch: ["^\\.github/workflows/ci\\.ya?ml$"],
+      matchStrings: [
+        "npx --yes markdownlint-cli2@(?<currentValue>\\S+) \\.",
+      ],
+      datasourceTemplate: "npm",
+      depNameTemplate: "markdownlint-cli2",
+    },
+    {
+      fileMatch: ["^\\.github/workflows/ci\\.ya?ml$"],
+      matchStrings: [
+        "uvx --from \"yamllint==(?<currentValue>\\S+)\" yamllint \\.",
+      ],
+      datasourceTemplate: "pypi",
+      depNameTemplate: "yamllint",
+    },
+    {
+      fileMatch: ["^\\.github/workflows/ci\\.ya?ml$"],
+      matchStrings: [
         "cargo install taplo-cli@(?<currentValue>\\S+) --locked",
       ],
       datasourceTemplate: "crate",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,38 @@
   ],
   regexManagers: [
     {
+      fileMatch: ["^\\.github/workflows/.*\\.ya?ml$"],
+      matchStrings: [
+        "uses: commitizen-tools/setup-cz@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '(?<currentValue>[^'\\s]+)'",
+      ],
+      datasourceTemplate: "pypi",
+      depNameTemplate: "commitizen",
+    },
+    {
+      fileMatch: ["^\\.github/workflows/.*\\.ya?ml$"],
+      matchStrings: [
+        "uses: zizmorcore/zizmor-action@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '(?<currentValue>[^'\\s]+)'",
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "zizmorcore/zizmor",
+    },
+    {
+      fileMatch: ["^\\.github/workflows/.*\\.ya?ml$"],
+      matchStrings: [
+        "uses: reviewdog/action-setup@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+reviewdog_version: '(?<currentValue>[^'\\s]+)'",
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "reviewdog/reviewdog",
+    },
+    {
+      fileMatch: ["^\\.github/workflows/.*\\.ya?ml$"],
+      matchStrings: [
+        "uses: j178/prek-action@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+prek-version: '(?<currentValue>[^'\\s]+)'",
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "j178/prek",
+    },
+    {
       fileMatch: ["^\\.github/workflows/ci\\.ya?ml$"],
       matchStrings: [
         "go install github\\.com/rhysd/actionlint/cmd/actionlint@(?<currentValue>v\\S+)",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,7 @@
   ],
   packageRules: [
     {
-      matchCategories: ["ci"],
+      matchFileNames: [".github/workflows/**"],
       addLabels: ["ci"],
       // automerge: true,
     },
@@ -30,7 +30,17 @@
       matchManagers: ["pre-commit"],
       addLabels: ["pre-commit"],
       // automerge: true,
-    }
+    },
+    {
+      matchFileNames: [".github/workflows/**"],
+      matchUpdateTypes: ["patch"],
+      automerge: true,
+    },
+    {
+      matchManagers: ["pre-commit"],
+      matchUpdateTypes: ["patch"],
+      automerge: true,
+    },
   ],
   regexManagers: [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Lint Markdown
         if: github.event_name != 'pull_request'
-        run: npx --yes markdownlint-cli2 .
+        run: npx --yes markdownlint-cli2@0.21.0 .
 
       - name: Set up reviewdog
         if: github.event_name == 'pull_request'
@@ -127,7 +127,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           markdownlint_rc=0
-          npx --yes markdownlint-cli2 . > /tmp/markdownlint-report.txt 2>&1 || markdownlint_rc=$?
+          npx --yes markdownlint-cli2@0.21.0 . > /tmp/markdownlint-report.txt 2>&1 || markdownlint_rc=$?
           reviewdog_rc=0
           reviewdog < /tmp/markdownlint-report.txt \
               -efm="%f:%l:%c %m" \
@@ -165,7 +165,7 @@ jobs:
 
       - name: Lint YAML
         if: github.event_name != 'pull_request'
-        run: uvx yamllint .
+        run: uvx --from "yamllint==1.38.0" yamllint .
 
       - name: Lint YAML (reviewdog)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
         with:
+          version: 'v1.22.0'
           inputs: ${{ steps.list-workflows.outputs.inputs }}
           # advanced-security: false  # must be false for private repo
 
@@ -122,6 +123,8 @@ jobs:
       - name: Set up reviewdog
         if: github.event_name == 'pull_request'
         uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
+        with:
+          reviewdog_version: 'v0.21.0'
 
       - name: Lint Markdown (reviewdog)
         if: github.event_name == 'pull_request'
@@ -162,6 +165,8 @@ jobs:
       - name: Install uv
         if: github.event_name != 'pull_request'
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: '0.10.6'
 
       - name: Lint YAML
         if: github.event_name != 'pull_request'
@@ -212,6 +217,7 @@ jobs:
       - name: Check prek
         uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1
         with:
+          prek-version: 'v0.3.3'
           extra-args: '--all-files --skip no-commit-to-branch'
 
   build-rust:
@@ -277,6 +283,8 @@ jobs:
       - name: Set up reviewdog
         if: github.event_name == 'pull_request'
         uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
+        with:
+          reviewdog_version: 'v0.21.0'
 
       - name: Run Clippy (reviewdog)
         if: github.event_name == 'pull_request'
@@ -382,6 +390,7 @@ jobs:
         uses: commitizen-tools/setup-cz@578def531656e522cd8978e6df62d626593e0a5f # v0.7.0
         with:
           python-version: '3.x'
+          version: '4.13.9'
 
       - name: Lint commit messages on push
         if: github.event_name == 'push'

--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -34,6 +34,7 @@ jobs:
         uses: commitizen-tools/setup-cz@578def531656e522cd8978e6df62d626593e0a5f # v0.7.0
         with:
           python-version: '3.x'
+          version: '4.13.9'
 
       - name: Lint pull request title
         run: cz check --message "$PR_TITLE"


### PR DESCRIPTION
## Summary
- pin versions for CI setup/runtime tools used in workflows
- add/update Renovate rules for those pinned versions
- scope CI labels/automerge to workflow-file updates