### PR TITLE
fix(ci): pin cargo-dist version for dist generate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,21 @@
   customManagers: [
     {
       customType: 'regex',
+      description: 'Update cargo-dist-version in dist-workspace.toml',
+      managerFilePatterns: [
+        '/^dist-workspace\\.toml$/',
+      ],
+      matchStrings: [
+        'cargo-dist-version\\s*=\\s*"(?<currentValue>[^"\\s]+)"',
+      ],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'axodotdev/cargo-dist',
+      versioningTemplate: 'semver',
+      extractVersionTemplate: '^v(?<version>.+)$',
+      autoReplaceStringTemplate: 'cargo-dist-version = "{{{newValue}}}"',
+    },
+    {
+      customType: 'regex',
       description: 'Update pinned GitHub Actions commits in dist-workspace.toml',
       managerFilePatterns: [
         '/^dist-workspace\\.toml$/',

--- a/.github/workflows/dist-generate.yml
+++ b/.github/workflows/dist-generate.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Install dist
         run: |
+          DIST_VERSION=$(grep -E '^\s*cargo-dist-version\s*=\s*"' dist-workspace.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          [ -n "${DIST_VERSION}" ] || { echo "Failed to read cargo-dist-version from dist-workspace.toml"; exit 1; }
           curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/axodotdev/cargo-dist/releases/latest/download/cargo-dist-installer.sh | sh
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/cargo-dist-installer.sh" | sh
 
       - name: Run dist generate
         run: dist generate


### PR DESCRIPTION
- pin cargo-dist installer version in dist-generate workflow based on dist-workspace.toml
- add Renovate custom manager to update cargo-dist-version automatically