### PR TITLE
ci(reviewdog): rely on default file filter mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,6 @@ jobs:
               -efm="%f:%l %m" \
               -name=markdownlint \
               -reporter=github-pr-review \
-              -filter-mode=added \
               -fail-level=error || reviewdog_rc=$?
           if [ $markdownlint_rc -ne 0 ] && ! grep -Eq '^[^:]+:[0-9]+(:[0-9]+)? ' /tmp/markdownlint-report.txt; then
             echo "::error title=markdownlint::markdownlint failed before producing parseable diagnostics"
@@ -317,7 +316,6 @@ jobs:
               -f=rdjsonl \
               -name=clippy \
               -reporter=github-pr-review \
-              -filter-mode=added \
               -fail-level=error \
               -tee || reviewdog_rc=$?
           if [ $clippy_rc -ne 0 ] && [ ! -s /tmp/clippy-rdjsonl.txt ]; then


### PR DESCRIPTION
## Summary
- remove explicit reviewdog filter-mode settings
- rely on reviewdog default filter mode (file) for consistency
- no behavior change intended beyond config simplification