### PR TITLE
chore(ci): normalize workflow hygiene and renovate regex

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,7 +83,7 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        'go install github\\.com/rhysd/actionlint/cmd/actionlint@(?<currentValue>v\\S+)',
+        'github\\.com/rhysd/actionlint/cmd/actionlint@(?<currentValue>v\\S+)',
       ],
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'rhysd/actionlint',
@@ -94,7 +94,7 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        'npx --yes markdownlint-cli2@(?<currentValue>\\S+) \\.',
+        'markdownlint-cli2@(?<currentValue>\\S+)',
       ],
       datasourceTemplate: 'npm',
       depNameTemplate: 'markdownlint-cli2',
@@ -105,10 +105,10 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        'uvx --from "yamllint==(?<currentValue>\\S+)" yamllint \\.',
+        'taplo-cli@(?<currentValue>\\S+)',
       ],
-      datasourceTemplate: 'pypi',
-      depNameTemplate: 'yamllint',
+      datasourceTemplate: 'crate',
+      depNameTemplate: 'taplo-cli',
     },
     {
       customType: 'regex',
@@ -116,10 +116,10 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        'cargo install taplo-cli@(?<currentValue>\\S+) --locked',
+        'yamllint==(?<currentValue>[^"\\s]+)',
       ],
-      datasourceTemplate: 'crate',
-      depNameTemplate: 'taplo-cli',
+      datasourceTemplate: 'pypi',
+      depNameTemplate: 'yamllint',
     },
   ],
   ignorePaths: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
 
       - name: Lint Markdown (reviewdog)
         if: github.event_name == 'pull_request'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           markdownlint_rc=0
           npx --yes markdownlint-cli2@0.21.0 . > /tmp/markdownlint-report.txt 2>&1 || markdownlint_rc=$?
@@ -145,8 +147,6 @@ jobs:
             exit $markdownlint_rc
           fi
           exit $reviewdog_rc
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint-yaml:
     name: Lint YAML
@@ -289,6 +289,8 @@ jobs:
 
       - name: Run Clippy (reviewdog)
         if: github.event_name == 'pull_request'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           clippy_rc=0
           cargo clippy --all-targets --all-features --message-format=json > /tmp/clippy-report.json || clippy_rc=$?
@@ -323,8 +325,6 @@ jobs:
             exit $clippy_rc
           fi
           exit $reviewdog_rc
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-rust:
     name: Test Rust

--- a/.github/workflows/dist-generate.yml
+++ b/.github/workflows/dist-generate.yml
@@ -65,6 +65,6 @@ jobs:
 
       - name: Push back to PR branch
         if: steps.diff.outputs.changed == 'true'
-        run: git push origin "HEAD:${PR_BRANCH}"
         env:
           PR_BRANCH: ${{ github.head_ref }}
+        run: git push origin "HEAD:${PR_BRANCH}"

--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -37,6 +37,6 @@ jobs:
           version: '4.13.9'
 
       - name: Lint pull request title
-        run: cz check --message "$PR_TITLE"
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+        run: cz check --message "$PR_TITLE"


### PR DESCRIPTION
## Summary
- reorder step keys from `run -> env` to `env -> run` where applicable
- remove explicit reviewdog filter mode to use default `file`
- simplify CI-related Renovate regex match strings without changing behavior