### PR TITLE
chore(renovate): allow minor automerge for renovate in ci workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -174,6 +174,19 @@
       automerge: true,
     },
     {
+      matchDepNames: [
+        'renovate',
+      ],
+      matchFileNames: [
+        '.github/workflows/ci.yaml',
+        '.github/workflows/ci.yml',
+      ],
+      matchUpdateTypes: [
+        'minor',
+      ],
+      automerge: true,
+    },
+    {
       matchManagers: [
         'pre-commit',
       ],


### PR DESCRIPTION
## Summary
- allow Renovate package minor updates to automerge in CI workflow files
- keep existing patch automerge rules unchanged

## Scope
- .github/renovate.json5