### PR TITLE
ci(toml): install taplo from pinned binary release

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -127,10 +127,10 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        'taplo-cli@(?<currentValue>\\S+)',
+        "TAPLO_VERSION: '(?<currentValue>[^']+)'",
       ],
-      datasourceTemplate: 'crate',
-      depNameTemplate: 'taplo-cli',
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'tamasfe/taplo',
     },
     {
       customType: 'regex',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Taplo
-        run: cargo install taplo-cli@0.10.0 --locked
+        env:
+          TAPLO_VERSION: '0.10.0'
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
+            | gzip -d > "$HOME/.local/bin/taplo"
+          chmod +x "$HOME/.local/bin/taplo"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check TOML format
         run: taplo fmt --check


### PR DESCRIPTION
- install taplo from pinned GitHub release binary
- track TAPLO_VERSION via Renovate (github-releases: tamasfe/taplo)