### PR TITLE
ci(labels): add workflow_dispatch trigger to label generator

### DIFF
--- a/.github/workflows/generate-labels.yml
+++ b/.github/workflows/generate-labels.yml
@@ -1,6 +1,7 @@
 name: Generate Labels
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
- Add workflow_dispatch trigger to the Generate Labels workflow
- Enable manual run of Generate Labels from the Actions tab