### PR TITLE
chore(ci): align label workflow naming

### DIFF
--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -8,8 +8,8 @@ permissions: {}
 
 jobs:
 
-  labeler:
-    name: labeler
+  label-pr:
+    name: Label PR
     if: github.event.action != 'edited'
     permissions:
       contents: read

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,4 @@
-name: Generate Labels
+name: Sync Labels
 
 on:
   workflow_dispatch:
@@ -6,18 +6,18 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/generate-labels.yml'
+      - '.github/workflows/sync-labels.yml'
       - '.github/labels/label-definition.yaml'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     paths:
-      - '.github/workflows/generate-labels.yml'
+      - '.github/workflows/sync-labels.yml'
       - '.github/labels/label-definition.yaml'
 
 jobs:
 
-  labeler:
-    name: labeler
+  sync-labels:
+    name: Sync Labels
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- rename label job in `manage-pull-requests` workflow to `label-pr` / `Label PR`
- rename `generate-labels` workflow file to `sync-labels`
- align workflow and job display names to `Sync Labels`
- update workflow self-path triggers to the renamed file