### PR TITLE
chore(rust): remove deprecated cargo authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "your-package-name"
-description = "A Rust package template"
 version = "0.1.0"
 edition = "2024"
+description = "A Rust package template"
 readme = "README.md"
-license = "Apache-2.0 OR MIT"
 repository = "https://github.com/<owner>/<repo>"
-authors = ["Your Name"]
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,12 @@ Update your package metadata in `Cargo.toml`:
 ```toml
 [package]
 name = "your-package-name"  # Replace with your package name
-description = "A Rust package template"
 version = "0.1.0"
 edition = "2024"
+description = "A Rust package template"
 readme = "README.md"
-license = "Apache-2.0 OR MIT"  # Replace with your license
 repository = "https://github.com/<owner>/<repo>"  # Replace with your repository URL
-authors = ["Your Name"]  # Replace with your name
+license = "Apache-2.0 OR MIT"  # Replace with your license
 ```
 
 This template repository includes [`LICENSE-APACHE`](LICENSE-APACHE) and [`LICENSE-MIT`](LICENSE-MIT) by default.


### PR DESCRIPTION
- Removes the deprecated `package.authors` field from `Cargo.toml`.
- Updates the README package metadata example to match the current Cargo manifest guidance and Tombi formatting.
- Follows the Cargo Book deprecation of `authors`, which is now kept only for backwards compatibility metadata such as `CARGO_PKG_AUTHORS`.
