### PR TITLE
ci: validate every changed json5 file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,11 @@ jobs:
             echo 'No JSON5 files found.'
             exit 0
           fi
-          npx --yes json5@2.2.3 "${json5_files[@]}" >/dev/null
+          exit_code=0
+          for json5_file in "${json5_files[@]}"; do
+            npx --yes json5@2.2.3 --validate "$json5_file" || exit_code=1
+          done
+          exit $exit_code
 
   lint-toml:
     name: Lint TOML


### PR DESCRIPTION
- The json5 CLI processes only its first positional argument and silently ignores the rest, so `npx json5 "${json5_files[@]}"` validated only the first changed file.
- Loop over the files with `--validate` so every file is checked and all failures are reported in one run.
