### PR TITLE
docs(readme): remove obsolete actions permissions setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,6 @@
 
 This is a template repository for a Rust package.
 
-## GitHub Actions Permissions Setup
-
-To enable GitHub Actions to run properly in your repository, you need to adjust the default permissions granted
-to the `GITHUB_TOKEN`.
-This is especially important for **private repositories**.
-
-Follow these steps to configure the permissions:
-
-1. Go to the **Settings** tab of your repository.
-2. On the left-hand menu, select **Actions/General**.
-3. Under the **Workflow permissions** section, ensure the following options are selected:
-   - **`Read and write permissions`**: This grants read and write access to the repository for all scopes.
-   - **`Allow GitHub Actions to create and approve pull requests`**: This allows GitHub Actions to create pull requests.
-4. Save the changes.
-
-![GitHub Actions permissions setup screenshot](https://github.com/user-attachments/assets/da55e896-e087-486e-aadc-7fc1283dc652)
-
-These settings are **necessary only for private repositories**. For public repositories, this configuration is not required.
-
 ## Package Setup
 
 Update your package metadata in `Cargo.toml`:


### PR DESCRIPTION
- Remove the `GitHub Actions Permissions Setup` section: the workflows declare explicit `permissions:` blocks, and release-plz creates pull requests with a GitHub App token, which the `Allow GitHub Actions to create and approve pull requests` toggle does not gate.
- The required setup (`GH_APP_CLIENT_ID` / `GH_APP_PRIVATE_KEY`) is already covered by the `GitHub App Setup (recommended)` section.
