### PR TITLE
ci: keep rustfmt diff so the check still fails the PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tool_name: rustfmt
+          cleanup: 'false'
 
       - name: Check Rustfmt diff
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
`reviewdog/action-suggester` defaults to `cleanup: true`, which stashes and drops the working-tree changes after reporting. The following Rustfmt diff check then runs against an already-clean tree and passes, so formatting violations never fail the PR.

Set `cleanup: false` so the diff is restored and the check keeps failing CI on violations.
