### PR TITLE
chore(renovate): follow full semver tags for github actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -148,6 +148,12 @@
   ],
   packageRules: [
     {
+      matchManagers: [
+        'github-actions',
+      ],
+      allowedVersions: '/^v?\\d+\\.\\d+\\.\\d+$/',
+    },
+    {
       matchFileNames: [
         '.github/workflows/**',
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -151,6 +151,9 @@
       matchManagers: [
         'github-actions',
       ],
+      matchDepTypes: [
+        'action',
+      ],
       allowedVersions: '/^v?\\d+\\.\\d+\\.\\d+$/',
     },
     {


### PR DESCRIPTION
Restrict `github-actions` updates to full semver release tags (`vX.Y.Z`) via `allowedVersions`.

Without this, a moving major tag (e.g. `v7`) can be selected ahead of its corresponding release (`v7.0.0`): the floating tag is evaluated by its commit date while the release is still held back by `minimumReleaseAge`, so the pin comment lands as `# v7` instead of `# v7.0.0`.

- Scoped to the `github-actions` manager only; custom managers and pre-commit are unaffected.
- All actions used in this repo are tagged with full semver, so nothing stops receiving updates.
