### PR TITLE
fix(renovate): use two spaces before inline comment in dist-workspace.toml

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,7 +31,7 @@
       ],
       datasourceTemplate: 'github-tags',
       versioningTemplate: 'semver',
-      autoReplaceStringTemplate: '"{{{depName}}}" = "{{{newDigest}}}" # {{{newValue}}}',
+      autoReplaceStringTemplate: '"{{{depName}}}" = "{{{newDigest}}}"  # {{{newValue}}}',
     },
     {
       customType: 'regex',


### PR DESCRIPTION
tombi requires two spaces before inline comments in TOML, but the `autoReplaceStringTemplate` for pinned GitHub Actions commits in `dist-workspace.toml` emitted only a single space. When Renovate updated a digest, that line was rewritten with one space and tombi's formatting check failed in CI (e.g. #263).

- Change the template to use two spaces before `#` so updated lines match tombi's formatting.
